### PR TITLE
Improved config mgmt and fixed out of bounds panic

### DIFF
--- a/analyzers/scan.go
+++ b/analyzers/scan.go
@@ -58,7 +58,7 @@ func Scan(args []string) {
 		}
 
 		// Fix up the path to make sure it is pointed at a directory (even if given a file)
-		fileInfo, err := os.Stat(strings.TrimRight(target_path, "..."))
+		fileInfo, err := os.Stat(strings.TrimRight(target_path, "."))
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -76,7 +76,7 @@ func Scan(args []string) {
 			}
 		}
 
-		err = os.Chdir(strings.TrimRight(target_path, "..."))
+		err = os.Chdir(strings.TrimRight(target_path, "."))
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -86,7 +86,7 @@ func Scan(args []string) {
 		}
 	}
 
-	generic_analyzers := LoadGenericAnalyzers(util.Config.YMLPath)
+	generic_analyzers := LoadGenericAnalyzers()
 	Analyzers = append(Analyzers, generic_analyzers[:]...)
 
 	// Begin timer

--- a/util/analyzers.yml
+++ b/util/analyzers.yml
@@ -33,66 +33,66 @@
 #         - "Printf"
 
 
+
+# Each entry specifies a source that should be considered untrusted
+# If the package already exists in the sources section, add the variable/function/type underneath 
+# Each package can contain multiple vulnerable sources.
 sources:
-  # Each entry specifies a source that should be considered untrusted
-  # If the package already exists in the sources section, add the variable/function/type underneath 
-  # Each package can contain multiple vulnerable sources.
-  sources:
-    # Sources that are defined in Go documentation as a "variable" go here (note: these variables will have an SSA type of "Global").
-    variables:
-      "os":
-        - "Args"
-    # Sources that are defined in Go documentation as a "function" go here.
-    functions:
-      "flag":
-        - "Arg"
-        - "Args"
-      "os":
-        - "Environ"
-        - "File"
-        - "FileInfo"
-        - "FileMode"
-        - "Readdir"
-        - "Readdirnames"
-        - "OpenFile"
-      "crypto/tls":
-        - "LoadX509KeyPair"
-        - "X509KeyPair"
-      "os/user":
-        - "Lookup"
-        - "LookupId"
-        - "Current"
-      "crypto/x509":
-        - "Subjects"
-      "io":
-        - "ReadAtLeast"
-        - "ReadFull"
-      "database/sql":
-        - "Query"
-        - "QueryRow"
-      "bytes":
-        - "String"
-        - "ReadBytes"
-        - "ReadByte"
-      "bufio":
-        - "Text"
-        - "Bytes"
-        - "ReadString"
-        - "ReadSlice"
-        - "ReadRune"
-        - "ReadLine"
-        - "ReadBytes"
-        - "ReadByte"
-      "archive/tar":
-        - "Next"
-        - "FileInfo"
-        - "Header"
-      "net/url":
-        - "ParseQuery"
-        - "ParseUriRequest"
-        - "Parse"
-        - "Query"
-    # Sources that are defined in Go documentation as a "type" go here (note: adding types will consider all functions that use that type to be tainted).
-    types:
-      "net/http":
-        - "Request"
+  # Sources that are defined in Go documentation as a "variable" go here (note: these variables will have an SSA type of "Global").
+  variables:
+    "os":
+      - "Args"
+  # Sources that are defined in Go documentation as a "function" go here.
+  functions:
+    "flag":
+      - "Arg"
+      - "Args"
+    "os":
+      - "Environ"
+      - "File"
+      - "FileInfo"
+      - "FileMode"
+      - "Readdir"
+      - "Readdirnames"
+      - "OpenFile"
+    "crypto/tls":
+      - "LoadX509KeyPair"
+      - "X509KeyPair"
+    "os/user":
+      - "Lookup"
+      - "LookupId"
+      - "Current"
+    "crypto/x509":
+      - "Subjects"
+    "io":
+      - "ReadAtLeast"
+      - "ReadFull"
+    "database/sql":
+      - "Query"
+      - "QueryRow"
+    "bytes":
+      - "String"
+      - "ReadBytes"
+      - "ReadByte"
+    "bufio":
+      - "Text"
+      - "Bytes"
+      - "ReadString"
+      - "ReadSlice"
+      - "ReadRune"
+      - "ReadLine"
+      - "ReadBytes"
+      - "ReadByte"
+    "archive/tar":
+      - "Next"
+      - "FileInfo"
+      - "Header"
+    "net/url":
+      - "ParseQuery"
+      - "ParseUriRequest"
+      - "Parse"
+      - "Query"
+  # Sources that are defined in Go documentation as a "type" go here (note: adding types will consider all functions that use that type to be tainted).
+  types:
+    "net/http":
+      - "Request"

--- a/util/config.go
+++ b/util/config.go
@@ -53,6 +53,8 @@ type Sources struct {
 	Variables map[string][]string `yaml:"variables"`
 	Functions map[string][]string `yaml:"functions"`
 	Types     map[string][]string `yaml:"types"`
+	// For compatibility with older analyzer.yml format
+	OldSrcs *Sources `yaml:"sources"`
 }
 
 var (
@@ -81,6 +83,15 @@ func LoadScanConfig() {
 	}
 	if err := yaml.Unmarshal(configBytes, &ScanConfig); err != nil {
 		log.Fatal(err)
+	}
+
+	// If OldSrcs isn't nil, then the config file is in the old format and we unnest the values
+	if ScanConfig.Sources.OldSrcs != nil {
+		ScanConfig.Sources.Functions = ScanConfig.Sources.OldSrcs.Functions
+		ScanConfig.Sources.Variables = ScanConfig.Sources.OldSrcs.Variables
+		ScanConfig.Sources.Types = ScanConfig.Sources.OldSrcs.Types
+		// Set OldSrcs to nil to let the garbage collector clean it up
+		ScanConfig.Sources.OldSrcs = nil
 	}
 
 	if Config.Debug {

--- a/util/finding.go
+++ b/util/finding.go
@@ -50,8 +50,11 @@ func StripArguments(parentFunction string) string {
 
 // prints out a finding; returns true if the finding was valid and false if the finding had the same source and sink
 func OutputFinding(finding Finding) bool {
-	// if the source and sink are the same, return false and do not print out the finding
+	if len(finding.Untrusted_Source) == 0 {
+		return false
+	}
 	if finding.Vulnerable_Function.SourceCode == finding.Untrusted_Source[0].SourceCode {
+		// if the source and sink are the same, return false and do not print out the finding
 		return false
 	}
 	if Config.OutputSarif {


### PR DESCRIPTION
Changed the way the config is loaded to use defined structs instead of nested maps of interface{}.  Now, the config is loaded into a struct during initialization and the values are referenced by the struct fields as appropriate.  This refrains from reading and parsing the config file twice (once when loading the default sources and again when loading any analyzers.

Additionally, this change adds a length check to fix the panic shown in https://github.com/praetorian-inc/gokart/issues/2