### PR TITLE
remove non-user-controllable input sources

### DIFF
--- a/util/analyzers.yml
+++ b/util/analyzers.yml
@@ -50,11 +50,6 @@ sources:
     "os":
       - "Environ"
       - "File"
-      - "FileInfo"
-      - "FileMode"
-      - "Readdir"
-      - "Readdirnames"
-      - "OpenFile"
     "crypto/tls":
       - "LoadX509KeyPair"
       - "X509KeyPair"


### PR DESCRIPTION
Removed several of the os.* sources that were producing FPs such as https://github.com/praetorian-inc/gokart/issues/12

os.OpenFile
os.Readdirnames
os.Readdir
os.FileMode
os.FileInfo

will not ever contain user-controllable data and thus can be safely removed.