### PR TITLE
Feature enhancement implementation for Issue #3 (Findings Output to File Flag)

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -24,6 +24,7 @@ import (
 )
 
 var yml string
+var outputPath string
 
 func init() {
 	goKartCmd.AddCommand(scanCmd)
@@ -32,6 +33,7 @@ func init() {
 	scanCmd.Flags().BoolP("verbose", "v", false, "outputs full trace of taint analysis")
 	scanCmd.Flags().BoolP("debug", "d", false, "outputs debug logs")
 	scanCmd.Flags().StringVarP(&yml, "input", "i", "", "input path to custom yml file")
+	scanCmd.Flags().StringVarP(&outputPath, "output", "o", "", "file path to write findings output instead of stdout")
 	goKartCmd.MarkFlagRequired("scan")
 }
 
@@ -49,7 +51,7 @@ Scans a Go module directory. To scan the current directory recursively, use goka
 		globals, _ := cmd.Flags().GetBool("globalsTainted")
 		verbose, _ := cmd.Flags().GetBool("verbose")
 		debug, _ := cmd.Flags().GetBool("debug")
-		util.InitConfig(globals, sarif, verbose, debug, yml)
+		util.InitConfig(globals, sarif, verbose, debug, outputPath, yml)
 		analyzers.Scan(args)
 	},
 }

--- a/util/config.go
+++ b/util/config.go
@@ -33,6 +33,7 @@ type ConfigType struct {
 	Debug       bool
 	Verbose     bool
 	YMLPath     string
+	OutputPath  string
 }
 
 // ConfigFile stores the values parsed from the configuration file
@@ -120,7 +121,7 @@ func LoadScanConfig() {
 }
 
 // InitConfig() parses the flags and sets the corresponding Config variables
-func InitConfig(globals bool, sarif bool, verbose bool, debug bool, yml string) {
+func InitConfig(globals bool, sarif bool, verbose bool, debug bool, output_path string, yml string) {
 	if yml == "" {
 		yml = getDefaultConfigPath()
 	} else if _, err := os.Stat(yml); err != nil {
@@ -132,6 +133,15 @@ func InitConfig(globals bool, sarif bool, verbose bool, debug bool, yml string) 
 	Config.OutputSarif = sarif
 	Config.Debug = debug
 	Config.Verbose = verbose
+	Config.OutputPath = ""
+	// get the absolute path of the output file to avoid issues when changing working directory for loading packages
+	if output_path != "" {
+		abs_output_path, err := filepath.Abs(output_path)
+		if err != nil {
+			log.Fatal(err)
+		}
+		Config.OutputPath = abs_output_path
+	}
 	Config.YMLPath = yml
 	LoadScanConfig()
 }

--- a/util/finding.go
+++ b/util/finding.go
@@ -48,8 +48,8 @@ func StripArguments(parentFunction string) string {
 	return strings.TrimSpace(functionName) + "(...)" + functionReturn
 }
 
-// prints out a finding; returns true if the finding was valid and false if the finding had the same source and sink
-func OutputFinding(finding Finding) bool {
+// returns true if the finding was valid and false if the finding had the same source and sink
+func IsValidFinding(finding Finding) bool {
 	if len(finding.Untrusted_Source) == 0 {
 		return false
 	}
@@ -57,6 +57,11 @@ func OutputFinding(finding Finding) bool {
 		// if the source and sink are the same, return false and do not print out the finding
 		return false
 	}
+	return true
+}
+
+// prints out a finding
+func OutputFinding(finding Finding) {
 	if Config.OutputSarif {
 		SarifRecordFinding(finding.Type, finding.message, finding.Vulnerable_Function.SourceFilename,
 			finding.Vulnerable_Function.SourceLineNum)
@@ -95,5 +100,4 @@ func OutputFinding(finding Finding) bool {
 		}
 		fmt.Printf("------------------------------------------------------------------------------\n")
 	}
-	return true
 }


### PR DESCRIPTION
- Adding the -o/--output flag for specifying a file path to write findings output to.
- Small refactoring to consolidate all findings output generation/processing into a single function in scan.go
- There is no default output file, it must be specified if this flag is used.
- ONLY redirects finding output - any stdout output that is not finding associated will not be written.