### PR TITLE
updated remote repository scanning functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,15 +141,24 @@ gokart scan go-test-bench/ -o gokart-go-test-bench.txt
 # Output scarif results to file
 gokart scan go-test-bench/ -o gokart-go-test-bench.txt -s
 
-# Scan remote repository (private repos require proper authentication)
+# Scan remote public repository 
 # Repository will be cloned locally, scanned and deleted afterwards
-gokart scan -r github.com/ShiftLeftSecurity/shiftleft-go-demo -v
+gokart scan -r https://github.com/ShiftLeftSecurity/shiftleft-go-demo -v
+
+# Specify the remote branch to scan
+gokart scan -r https://github.com/ShiftLeftSecurity/shiftleft-go-demo -b actions_fix
+
+# Scan remote private repository via ssh
+gokart scan -r git@github.com:Contrast-Security-OSS/go-test-bench.git 
+
+# Scan remote private repository and optionally specify a key for ssh authentication 
+gokart scan -r git@github.com:Contrast-Security-OSS/go-test-bench.git -k /home/gokart/.ssh/github_rsa_key
 
 # Use remote scan and output flags together for seamless security reviews
-gokart scan -r github.com/ShiftLeftSecurity/shiftleft-go-demo -o gokart-shiftleft-go-demo.txt -v 
+gokart scan -r https://github.com/ShiftLeftSecurity/shiftleft-go-demo -o gokart-shiftleft-go-demo.txt -v 
 
 # Use remote scan, output and sarif flags for frictionless integration into CI/CD
-gokart scan -r github.com/ShiftLeftSecurity/shiftleft-go-demo -o gokart-shiftleft-go-demo.txt -s
+gokart scan -r https://github.com/ShiftLeftSecurity/shiftleft-go-demo -o gokart-shiftleft-go-demo.txt -s
 ```
 
 To test out the extensibility of GoKart, you can modify the configuration file that GoKart uses to

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -65,13 +65,17 @@ Scans a Go module directory. To scan the current directory recursively, use goka
 		// If remoteModule was set, clone the remote repository and scan it
 		if len(remoteModule) != 0 {
 			moduleTempDir, err := ioutil.TempDir(".", "gokart")
+			if err != nil {
+				log.Fatal("Error creating temporary directory: ", err.Error())
+			}
+			defer util.CleanupModule(moduleTempDir)
 
 			err = util.CloneModule(moduleTempDir, remoteModule, remoteBranch, keyFile)
 
 			if err != nil {
+				util.CleanupModule(moduleTempDir)
 				log.Fatal("Error cloning remote repository: ", err.Error())
 			}
-			defer util.CleanupModule(moduleTempDir)
 			// If passing in a module - the other arguments are wiped out!
 			args = append([]string{}, moduleTempDir+"/...")
 		}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -18,6 +18,7 @@ Package cmd implements a simple command line interface using cobra
 package cmd
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
 
@@ -28,8 +29,10 @@ import (
 
 var yml string
 var exitCode bool
-var goModName string
+var remoteModule string
 var outputPath string
+var remoteBranch string
+var keyFile string
 
 func init() {
 	goKartCmd.AddCommand(scanCmd)
@@ -38,7 +41,9 @@ func init() {
 	scanCmd.Flags().BoolP("verbose", "v", false, "outputs full trace of taint analysis")
 	scanCmd.Flags().BoolP("debug", "d", false, "outputs debug logs")
 	scanCmd.Flags().BoolP("exitCode", "x", false, "return non-nil exit code on potential vulnerabilities or scanner failure")
-	scanCmd.Flags().StringVarP(&goModName, "remoteModule", "r", "", "Remote gomodule to scan")
+	scanCmd.Flags().StringVarP(&remoteModule, "remoteModule", "r", "", "Remote gomodule to scan")
+	scanCmd.Flags().StringVarP(&remoteBranch, "remoteBranch", "b", "", "Branch of remote module to scan")
+	scanCmd.Flags().StringVarP(&keyFile, "keyFile", "k", "", "SSH Keyfile to use for ssh authentication for remote git repository scanning")
 	scanCmd.Flags().StringVarP(&yml, "input", "i", "", "input path to custom yml file")
 	scanCmd.Flags().StringVarP(&outputPath, "output", "o", "", "file path to write findings output instead of stdout")
 	goKartCmd.MarkFlagRequired("scan")
@@ -57,19 +62,18 @@ Scans a Go module directory. To scan the current directory recursively, use goka
 		exitCode, _ := cmd.Flags().GetBool("exitCode")
 		util.InitConfig(globals, sarif, verbose, debug, outputPath, yml, exitCode)
 
-		// If gomodname flag is set to a non-empty value then clone the repo and scan it
-		if len(goModName) != 0 {
-			modDirName, err := util.ParseModuleName(goModName)
+		// If remoteModule was set, clone the remote repository and scan it
+		if len(remoteModule) != 0 {
+			moduleTempDir, err := ioutil.TempDir(".", "gokart")
+
+			err = util.CloneModule(moduleTempDir, remoteModule, remoteBranch, keyFile)
+
 			if err != nil {
-				log.Fatal(err)
+				log.Fatal("Error cloning remote repository: ", err.Error())
 			}
-			err = util.CloneModule(modDirName, "https://"+goModName)
-			if err != nil {
-				log.Fatal("GoKart was unable to get the new racetrack. Ensure track repository is open to the public or that your access tokens are configured correctly for Private ones.")
-			}
-			defer util.CleanupModule(modDirName)
+			defer util.CleanupModule(moduleTempDir)
 			// If passing in a module - the other arguments are wiped out!
-			args = append([]string{}, modDirName+"/...")
+			args = append([]string{}, moduleTempDir+"/...")
 		}
 
 		// recursively scan the current directory if no arguments are passed in

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"testing"
-	"strings"
 	"fmt"
-	"os"
 	"io/ioutil"
-	
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/praetorian-inc/gokart/util"
 	"github.com/spf13/cobra"
 )
@@ -20,20 +20,20 @@ func TestScanCommand(t *testing.T) {
 	}
 	fmt.Printf("Current dir is: %s", cur_dir)
 	var tests = []struct {
-		args []string
+		args              []string
 		expected_lastline string
-		moduledir string
+		moduledir         string
 	}{
-		{[]string{"scan"},"GoKart found 0 potentially vulnerable functions", ""},
-		{[]string{"scan","-r", "github.com/Contrast-Security-OSS/go-test-bench"}, "GoKart found 8 potentially vulnerable functions", cur_dir+"/go-test-bench"},
-		{[]string{"scan","-r", "github.com/praetorian-inc/gokart"}, "GoKart found 0 potentially vulnerable functions", cur_dir+"/gokart"},
+		{[]string{"scan"}, "GoKart found 0 potentially vulnerable functions", ""},
+		{[]string{"scan", "-r", "https://github.com/Contrast-Security-OSS/go-test-bench"}, "GoKart found 8 potentially vulnerable functions", cur_dir + "/go-test-bench"},
+		{[]string{"scan", "-r", "https://github.com/praetorian-inc/gokart"}, "GoKart found 0 potentially vulnerable functions", cur_dir + "/gokart"},
 		{[]string{"scan", "--help"}, "  -v, --verbose               outputs full trace of taint analysis", ""},
 	}
 	for _, tt := range tests {
 		t.Run(strings.Join(tt.args, " "), func(t *testing.T) {
-			
+
 			if err != nil {
-				t.Fatalf("Failed! %s",err)
+				t.Fatalf("Failed! %s", err)
 			}
 
 			// fetch last line of output from scan command
@@ -46,13 +46,13 @@ func TestScanCommand(t *testing.T) {
 				}
 			}
 			if lastline != tt.expected_lastline {
-				t.Fatalf("Failed! Expected: %s\nGot: %s\n",tt.expected_lastline,lastline,)
-			} 
+				t.Fatalf("Failed! Expected: %s\nGot: %s\n", tt.expected_lastline, lastline)
+			}
 		})
 	}
 }
 
-func ExecuteCommand(cmd *cobra.Command,args []string) (string) {
+func ExecuteCommand(cmd *cobra.Command, args []string) string {
 
 	// change stdout to something we can read from to capture command out
 	// Not sure if this could potentially cause issues if buffer gets too full


### PR DESCRIPTION
Updated the remote scanning functionality and fixed a few bugs associated with it (also changed line endings on a few files):

Previously, scanning a repository that had a name conflicting with a file already present would cause an error. Updated to use temporary directory file names instead.
```bash
./gokart scan -r github.com/praetorian-inc/gokart
Using config found at /Users/tomis/.gokart/analyzers.yml
Loading new racetrack: https://github.com/praetorian-inc/gokart
2021/09/15 10:14:53 GoKart was unable to get the new racetrack. Ensure track repository is open to the public or that your access tokens are configured correctly for Private ones.
```

Previously, scanning a remote repository only worked for https, and did not support any types of authentication for a private repository. Now by specifying a git url (like when using git clone) the default ssh keys will be attempted. Optionally, an ssh_key file can also be specified. Increased verbosity of error messages around the behavior was also added, it's now possible to scan a remote private repository
```bash
[/Users/tomis/Desktop/gokart]$ ./gokart scan -r https://github.com/praetorian-inc/test-go
Using config found at /Users/tomis/.gokart/analyzers.yml
2021/09/15 10:17:16 Cloning new remote module: https://github.com/praetorian-inc/test-go
2021/09/15 10:17:16 Error cloning remote repository: authentication required
[/Users/tomis/Desktop/gokart]$ ./gokart scan -r git@github.com/praetorian-inc/test-go.git
Using config found at /Users/tomis/.gokart/analyzers.yml
2021/09/15 10:17:30 Cloning new remote module: git@github.com/praetorian-inc/test-go.git
2021/09/15 10:17:30 Error cloning remote repository: repository not found
```

A branch can be specified when remote scanning:
```
[/Users/tomis/Desktop/gokart]$ ./gokart scan -r https://github.com/praetorian-inc/gokart -b does-not-exist
Using config found at /Users/tomis/.gokart/analyzers.yml
2021/09/15 10:19:40 Cloning new remote module: https://github.com/praetorian-inc/gokart
2021/09/15 10:19:40 Cloning with remote branch reference: does-not-exist
Enumerating objects: 180, done.
Counting objects: 100% (180/180), done.
Compressing objects: 100% (114/114), done.
Total 180 (delta 97), reused 127 (delta 59), pack-reused 0
2021/09/15 10:19:40 Error cloning remote repository: reference not found
```