### PR TITLE
output finding information as json

### DIFF
--- a/analyzers/scan.go
+++ b/analyzers/scan.go
@@ -19,6 +19,7 @@ and a generic analyzer based on recursive taint propagation
 package analyzers
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -71,6 +72,14 @@ func OutputResults(results []util.Finding, success bool) error {
 		os.Stdout = outputFile
 	}
 
+	if util.Config.OutputJSON && success {
+		res, err := json.Marshal(results)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(res))
+	}
+
 	for _, finding := range results {
 		util.OutputFinding(finding)
 	}
@@ -99,6 +108,8 @@ func Scan(args []string) ([]util.Finding, error) {
 
 	if util.Config.OutputSarif {
 		util.InitSarifReporting()
+	} else if util.Config.OutputJSON {
+		// don't print out anything
 	} else {
 		fmt.Printf("\nRevving engines VRMMM VRMMM\n3...2...1...Go!\n")
 	}
@@ -186,7 +197,8 @@ func Scan(args []string) ([]util.Finding, error) {
 		log.Fatalf("Error opening output file: %v", err)
 	}
 
-	if !util.Config.OutputSarif && success {
+	// Don't print out messages if JSON or SARIF output
+	if !(util.Config.OutputSarif || util.Config.OutputJSON) && success {
 		fmt.Println("\nRace Complete! Analysis took", scan_time, "and", util.FilesFound, "Go files were scanned (including imported packages)")
 		fmt.Printf("GoKart found %d potentially vulnerable functions\n", len(filteredResults))
 	}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -34,6 +34,7 @@ var outputPath string
 func init() {
 	goKartCmd.AddCommand(scanCmd)
 	scanCmd.Flags().BoolP("sarif", "s", false, "outputs findings in SARIF form")
+	scanCmd.Flags().BoolP("json", "j", false, "outputs findings in JSON")
 	scanCmd.Flags().BoolP("globalsTainted", "g", false, "marks global variables as dangerous")
 	scanCmd.Flags().BoolP("verbose", "v", false, "outputs full trace of taint analysis")
 	scanCmd.Flags().BoolP("debug", "d", false, "outputs debug logs")
@@ -51,11 +52,12 @@ var scanCmd = &cobra.Command{
 Scans a Go module directory. To scan the current directory recursively, use gokart scan. To scan a specific directory, use gokart scan <directory>.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		sarif, _ := cmd.Flags().GetBool("sarif")
+		json, _ := cmd.Flags().GetBool("json")
 		globals, _ := cmd.Flags().GetBool("globalsTainted")
 		verbose, _ := cmd.Flags().GetBool("verbose")
 		debug, _ := cmd.Flags().GetBool("debug")
 		exitCode, _ := cmd.Flags().GetBool("exitCode")
-		util.InitConfig(globals, sarif, verbose, debug, outputPath, yml, exitCode)
+		util.InitConfig(globals, sarif, json, verbose, debug, outputPath, yml, exitCode)
 
 		// If gomodname flag is set to a non-empty value then clone the repo and scan it
 		if len(goModName) != 0 {

--- a/util/config.go
+++ b/util/config.go
@@ -30,6 +30,7 @@ import (
 type ConfigType struct {
 	GlobalsSafe bool
 	OutputSarif bool
+	OutputJSON  bool
 	Debug       bool
 	Verbose     bool
 	ExitCode    bool
@@ -122,16 +123,19 @@ func LoadScanConfig() {
 }
 
 // InitConfig() parses the flags and sets the corresponding Config variables
-func InitConfig(globals bool, sarif bool, verbose bool, debug bool, output_path string, yml string, exitCode bool) {
+func InitConfig(globals bool, sarif bool, json bool, verbose bool, debug bool, output_path string, yml string, exitCode bool) {
 	if yml == "" {
 		yml = getDefaultConfigPath()
 	} else if _, err := os.Stat(yml); err != nil {
 		log.Fatalf("failed to find the provided config file at %s: %v", yml, err)
 	}
-	fmt.Printf("Using config found at %s\n", yml)
+	if !(json || sarif) {
+		fmt.Printf("Using config found at %s\n", yml)
+	}
 
 	Config.GlobalsSafe = !globals
 	Config.OutputSarif = sarif
+	Config.OutputJSON = json
 	Config.Debug = debug
 	Config.Verbose = verbose
 	Config.ExitCode = exitCode

--- a/util/finding.go
+++ b/util/finding.go
@@ -73,6 +73,9 @@ func OutputFinding(finding Finding) {
 	if Config.OutputSarif {
 		SarifRecordFinding(finding.Type, finding.message, finding.Vulnerable_Function.SourceFilename,
 			finding.Vulnerable_Function.SourceLineNum)
+	} else if Config.OutputJSON {
+		// the JSON output is printed in OutputResults in scan.go, so nothing to do for this finding
+		return
 	} else {
 		yellow := color.New(color.FgYellow).SprintFunc()
 		cyan := color.New(color.FgCyan).SprintFunc()


### PR DESCRIPTION
Added a -j flag to output the finding information as JSON. Modified the -s flag to only output the sarif data. This allows for piping into programs like jq without an issue
```
[/Users/tomis/Desktop/gokart]$ ./gokart scan ../go-test-bench -s  | jq
parse error: Invalid numeric literal at line 1, column 6
```

now
```
[/Users/tomis/Desktop/gokart]$ ./gokart scan ../go-test-bench -s  | jq                                         
{                       
  "version": "2.1.0",              
  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json", 
  "runs": [  
...
```

```
[/Users/tomis/Desktop/gokart]$ ./gokart scan ../go-test-bench -j | jq                                                                                                                                                         
[                                                                                                                                                                                                                             
  {                                                                                                                                                                                                                           
    "Vulnerable_Function": {                                                                                   
      "SourceCode": "\t\tcommand = exec.Command(\"echo\", userInput)", 
... 
```