### PR TITLE
don't print status of cloning message when scanning remote repository…

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -72,7 +72,8 @@ Scans a Go module directory. To scan the current directory recursively, use goka
 			}
 			defer util.CleanupModule(moduleTempDir)
 
-			err = util.CloneModule(moduleTempDir, remoteModule, remoteBranch, keyFile)
+			// Clone the module, if the output format is JSON or SARIF don't print any progress to stdout
+			err = util.CloneModule(moduleTempDir, remoteModule, remoteBranch, keyFile, json || sarif)
 
 			if err != nil {
 				util.CleanupModule(moduleTempDir)

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -25,7 +25,7 @@ func TestScanCommand(t *testing.T) {
 		moduledir         string
 	}{
 		{[]string{"scan"}, "GoKart found 0 potentially vulnerable functions", ""},
-		{[]string{"scan", "-r", "github.com/praetorian-inc/gokart"}, "GoKart found 0 potentially vulnerable functions", cur_dir + "/gokart"},
+        {[]string{"scan", "-r", "https://github.com/praetorian-inc/gokart"}, "GoKart found 0 potentially vulnerable functions", cur_dir + "/gokart"},
 		{[]string{"scan", "--help"}, "  -v, --verbose               outputs full trace of taint analysis", ""},
 	}
 	for _, tt := range tests {

--- a/util/finding.go
+++ b/util/finding.go
@@ -104,6 +104,7 @@ func OutputFinding(finding Finding, outputColor bool) {
 		yellow := color.New(color.FgYellow).SprintFunc()
 		cyan := color.New(color.FgCyan).SprintFunc()
 		green := color.New(color.FgGreen).SprintFunc()
+		red := color.New(color.FgRed).SprintFunc()
 
 		sinkParentNoArgs := StripArguments(finding.Vulnerable_Function.ParentFunction)
 
@@ -114,7 +115,11 @@ func OutputFinding(finding Finding, outputColor bool) {
 		}
 		fmt.Printf("%s:%d\nVulnerable Function: [ %s ]\n", finding.Vulnerable_Function.SourceFilename, finding.Vulnerable_Function.SourceLineNum, sinkParentNoArgs)
 		fmt.Printf("      %d:\t%s\n", finding.Vulnerable_Function.SourceLineNum-1, GrabSourceCode(finding.Vulnerable_Function.SourceFilename, finding.Vulnerable_Function.SourceLineNum-1))
-		fmt.Printf("    > %d:\t%s\n", finding.Vulnerable_Function.SourceLineNum, finding.Vulnerable_Function.SourceCode)
+		if outputColor {
+			fmt.Printf("    > %d:\t%s\n", finding.Vulnerable_Function.SourceLineNum, red(finding.Vulnerable_Function.SourceCode))
+		} else {
+			fmt.Printf("    > %d:\t%s\n", finding.Vulnerable_Function.SourceLineNum, finding.Vulnerable_Function.SourceCode)
+		}
 		fmt.Printf("      %d:\t%s\n", finding.Vulnerable_Function.SourceLineNum+1, GrabSourceCode(finding.Vulnerable_Function.SourceFilename, finding.Vulnerable_Function.SourceLineNum+1))
 
 		if finding.Untrusted_Source != nil {
@@ -123,7 +128,11 @@ func OutputFinding(finding Finding, outputColor bool) {
 			fmt.Printf("\n%s:%d\n", source.SourceFilename, source.SourceLineNum)
 			fmt.Printf("Source of Untrusted Input: [ %s ]\n", StripArguments(source.ParentFunction))
 			fmt.Printf("      %d:\t%s\n", source.SourceLineNum-1, GrabSourceCode(source.SourceFilename, source.SourceLineNum-1))
-			fmt.Printf("    > %d:\t%s\n", source.SourceLineNum, source.SourceCode)
+			if outputColor {
+				fmt.Printf("    > %d:\t%s\n", source.SourceLineNum, red(source.SourceCode))
+			} else {
+				fmt.Printf("    > %d:\t%s\n", source.SourceLineNum, source.SourceCode)
+			}
 			fmt.Printf("      %d:\t%s\n", source.SourceLineNum+1, GrabSourceCode(source.SourceFilename, source.SourceLineNum+1))
 
 			if Config.Verbose {

--- a/util/module.go
+++ b/util/module.go
@@ -25,13 +25,17 @@ import (
 
 // CloneModule clones a remote git repository
 // An optional keyfile may be specified for use in ssh authentication
-func CloneModule(dir string, url string, branch string, keyFile string) error {
+// If quiet is true, don't print clone progress to stdout
+func CloneModule(dir string, url string, branch string, keyFile string, quiet bool) error {
 	var cloneOptions git.CloneOptions
 
-	log.Printf("Cloning new remote module: %s\n", url)
 	cloneOptions = git.CloneOptions{
-		URL:      url,
-		Progress: os.Stdout,
+		URL: url,
+	}
+
+	if !quiet {
+		log.Printf("Cloning new remote module: %s\n", url)
+		cloneOptions.Progress = os.Stdout
 	}
 
 	if len(branch) != 0 {


### PR DESCRIPTION
… and outputting json or sarif

Remove the status output for scanning remote repositories when specifying json our sarif as the output type