### PR TITLE
Update removal of bad packages from package list.

### DIFF
--- a/run/run.go
+++ b/run/run.go
@@ -89,7 +89,7 @@ func LoadPackages(packagesList ...string) ([]*packages.Package, bool, error) {
 	return pkgs, success, nil
 }
 
-// RemoveBadPackages takes the full list of packages and a map containing the packages that were
+// RemoveBadPackages takes the full list of packages and a map containing the packages that produced errors while being loaded.
 func RemoveBadPackages(allPackages []*packages.Package, badPackages map[*packages.Package]bool) []*packages.Package {
 	buf := new(strings.Builder)
 	goodPackages := make([]*packages.Package, 0, len(allPackages))

--- a/run/run_test.go
+++ b/run/run_test.go
@@ -1,0 +1,72 @@
+package run
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/tools/go/packages"
+)
+
+var (
+	pkgFoo = &packages.Package{
+		ID: "foo",
+	}
+	pkgBar = &packages.Package{
+		ID: "bar",
+	}
+	pkgBaz = &packages.Package{
+		ID: "baz",
+	}
+)
+
+func TestRemoveBadPackages(t *testing.T) {
+	testCases := []struct {
+		name        string
+		badPackages map[*packages.Package]bool
+		want        []*packages.Package
+	}{
+		{
+			name:        "no bad packages",
+			badPackages: nil,
+			want:        []*packages.Package{pkgFoo, pkgBar, pkgBaz},
+		},
+		{
+			name: "one bad package",
+			badPackages: map[*packages.Package]bool{
+				pkgFoo: true,
+			},
+			want: []*packages.Package{pkgBar, pkgBaz},
+		},
+		{
+			name: "all packages are bad",
+			badPackages: map[*packages.Package]bool{
+				pkgFoo: true,
+				pkgBar: true,
+				pkgBaz: true,
+			},
+			want: []*packages.Package{},
+		},
+	}
+
+	sortSlices := cmp.Transformer("Sort", func(in []*packages.Package) []*packages.Package {
+		out := append([]*packages.Package(nil), in...)
+		sort.SliceStable(out, func(i, j int) bool {
+			return out[i].ID < out[j].ID
+		})
+		return out
+	})
+	cmpPkgs := cmp.Comparer(func(x, y *packages.Package) bool {
+		return x.ID == y.ID
+	})
+
+	allPackages := []*packages.Package{pkgFoo, pkgBar, pkgBaz}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RemoveBadPackages(allPackages, tc.badPackages)
+			if diff := cmp.Diff(tc.want, got, cmpPkgs, sortSlices); diff != "" {
+				t.Errorf("RemoveBadPackages(%v, %v) returned an unexpected diff (-want +got):\n%s", allPackages, tc.badPackages, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Updated the way that bad packages are removed from the package list to be more efficient. The previous method ran in O(n*m) time (n = num of all packages, m = num of bad packages), and the updated method runs in O(n) and also cleans up some of the surrounding code to make it more readable.

Side note, [this constant](https://github.com/praetorian-inc/gokart/blob/4f4269024a5a34a68f9b71e32cce98622f5c0f28/run/run.go#L57) is deprecated and it's recommended to update to explicitly declaring which fields you need. 